### PR TITLE
Fix PDF preview to show 7th semester syllabus

### DIFF
--- a/src/pages/syllabus.jsx
+++ b/src/pages/syllabus.jsx
@@ -60,7 +60,7 @@ export default function Home() {
             {/* https://drive.google.com/file/d/1N_ttI4ut41bQ6gAYiZX9HSoOa7nmjz1l/view?usp=sharing */}
             <div className="flex justify-center">
               <iframe
-                src="https://drive.google.com/file/d/1N_ttI4ut41bQ6gAYiZX9HSoOa7nmjz1l/preview"
+                src="https://drive.google.com/file/d/1atnG_ZHSUvxUKCZM1az56YpLkdRostp8/preview"
                 height="1024"
                 allow="autoplay"
                 frameborder="0"


### PR DESCRIPTION
Issue:
- The page title and download button were updated correctly
- However, the embedded PDF preview was still showing the old 6th semester syllabus

Changes:
- Updated the iframe `src` to point to the new 7th semester syllabus on Google Drive
- Preview now correctly displays 7th semester content

Related:
- Follow-up to PR #13