### PR TITLE
Update Multicore Architecture and Programming Lab link 

### DIFF
--- a/src/pages/ci7.jsx
+++ b/src/pages/ci7.jsx
@@ -168,7 +168,7 @@ const cseaimlsem7 = [
   {
     title: 'MULTICORE ARCHITECTURE and PROGRAMMING Lab',
     description: '(0:0:1) CIL73',
-    link: 'https://drive.google.com/drive/folders/1IdqLJffstiIB4PyMpdzgkG-LghuWb8fM?usp=sharing',
+    link: 'https://drive.google.com/drive/folders/10lOY-DJ7WfXh7zETRoLv9kkFRooaDmIs?usp=drive_link',
     github: '',
   },
   {


### PR DESCRIPTION
Changes:

- Updated the old "View" link of Multicore Architecture and Programming Lab, to new appropriate link.
- It directs to new folder in shared drive.
- Old link is completely removed. (The old link it directs to: https://drive.google.com/drive/folders/1IdqLJffstiIB4PyMpdzgkG-LghuWb8fM)