### PR TITLE
fix(links): prevent spam link submissions and handle React keys corre…

### DIFF
--- a/src/components/LinksComponent.jsx
+++ b/src/components/LinksComponent.jsx
@@ -36,6 +36,14 @@ function ContributeModal({ isOpen, onClose, onSubmit }) {
       return
     }
 
+    if (
+      title.trim().toLowerCase() === 'q' ||
+      title.trim().toLowerCase() === 'test'
+    ) {
+      setSubmitError('Please enter a valid, descriptive title')
+      return
+    }
+
     const validLinks = links.filter(
       (link) => link.url.trim() && link.description.trim()
     )
@@ -173,7 +181,17 @@ export function LinksComponent() {
           .orderBy('createdate', 'desc')
           .get()
         console.log(response)
-        const data = response.docs.map((doc) => doc.data())
+        const data = response.docs
+          .map((doc) => ({
+            id: doc.id,
+            ...doc.data(),
+          }))
+          .filter(
+            (item) =>
+              item.title &&
+              item.title.trim().toLowerCase() !== 'q' &&
+              item.title.trim().toLowerCase() !== 'test'
+          )
         setOtherlinks(data)
         setLoading(false)
       } catch (error) {
@@ -251,7 +269,17 @@ export function LinksComponent() {
                 .collection('otherlinks')
                 .orderBy('createdate', 'desc')
                 .get()
-              const newData = response.docs.map((doc) => doc.data())
+              const newData = response.docs
+                .map((doc) => ({
+                  id: doc.id,
+                  ...doc.data(),
+                }))
+                .filter(
+                  (item) =>
+                    item.title &&
+                    item.title.trim().toLowerCase() !== 'q' &&
+                    item.title.trim().toLowerCase() !== 'test'
+                )
               setOtherlinks(newData)
             } catch (err) {
               console.error('Error submitting links:', err)


### PR DESCRIPTION
This PR removes spam/test submissions and implements safeguards to prevent them in the future. It also fixes a React list key warning.

### Key Changes:

1. **Database Cleanup**
* Removed existing spam documents (with titles "q" and "Test") from the live Firestore collection.

2. **Spam Submission Prevention**
* Added form validation to block new link contributions containing lazy/spam titles like "q" or "test" (case-insensitive).

3. **Display-time Filter**
* Added a frontend filter to ensure any records matching these spam titles are hidden from the UI.

4. **React List Key Fix**
* Mapped the unique Firestore document `id` into the data array, resolving React console warnings caused by `item.id` being undefined.